### PR TITLE
docs: Fix a few typos

### DIFF
--- a/arvideo.py
+++ b/arvideo.py
@@ -208,7 +208,7 @@ def _first_half(data):
 
 
 def _second_half(data):
-    """Helper function to precompute the nonzeror values in a 15 bit datum.
+    """Helper function to precompute the nonzero values in a 15 bit datum.
     """
     # data has to be 15 bits wide
     streamlen = 0

--- a/libardrone.py
+++ b/libardrone.py
@@ -148,7 +148,7 @@ class ARDrone(object):
     def commwdg(self):
         """Communication watchdog signal.
 
-        This needs to be send regulary to keep the communication w/ the drone
+        This needs to be send regular to keep the communication w/ the drone
         alive.
         """
         self.at(at_comwdg)
@@ -295,7 +295,7 @@ def at_anim(seq, anim, d):
     Makes the drone execute a predefined movement (animation).
 
     Parameters:
-    seq -- sequcence number
+    seq -- sequence number
     anim -- Integer: animation to play
     d -- Integer: total duration in sections of the animation
     """


### PR DESCRIPTION
There are small typos in:
- arvideo.py
- libardrone.py

Fixes:
- Should read `sequence` rather than `sequcence`.
- Should read `regular` rather than `regulary`.
- Should read `nonzero` rather than `nonzeror`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md